### PR TITLE
Fix skip-existing infinite loop and add --debug flag

### DIFF
--- a/src/yt_community_post_archiver/archiver.py
+++ b/src/yt_community_post_archiver/archiver.py
@@ -74,6 +74,11 @@ class Archiver:
         self.save_comments_types = settings.save_comments_types
         self.max_comments = settings.max_comments
         self.original_handle = ""
+        self.debug = settings.debug
+
+    def _debug(self, msg: str):
+        if self.debug:
+            print(f"[DEBUG] {msg}")
 
     def set_cookies(self):
         if self.cookie_path is None:
@@ -144,6 +149,7 @@ class Archiver:
                     save_comments_types=self.save_comments_types,
                     max_comments=self.max_comments,
                     original_handle=self.original_handle,
+                    debug=self.debug,
                 )
                 post_builder.process_post()
 
@@ -174,8 +180,13 @@ class Archiver:
             try:
                 # Check the current URL isn't a post. If it is, try closing the current tab;
                 # if only the original tab was left, then the root URL was a post, so halt.
-                if get_true_comment_count(self.driver) is not None:
-                    if close_current_tab(self.driver, self.original_handle) == 1:
+                comment_count = get_true_comment_count(self.driver)
+                if comment_count is not None:
+                    tabs_left = close_current_tab(self.driver, self.original_handle)
+                    self._debug(
+                        f"could_scroll: found comment_count={comment_count} on current page, tabs_left={tabs_left}"
+                    )
+                    if tabs_left == 1:
                         return False
 
                 self.driver.execute_script("window.scrollBy(0, 500);")
@@ -205,6 +216,7 @@ class Archiver:
 
             while True:
                 posts = self.find_posts()
+                self._debug(f"Found {len(posts)} new posts on page")
                 for post, url in posts:
                     if self.at_max_posts():
                         print(f"Hit maximum posts ({self.max_posts}). Halting.")
@@ -215,9 +227,14 @@ class Archiver:
                     if not self.should_skip_post(url) and url not in self.seen:
                         self.handle_post(post, url)
                     else:
+                        self.seen.add(url)
                         print(f"Skipping `{url}` as it already exists.")
 
-                if not self.could_scroll():
+                can_scroll = self.could_scroll()
+                self._debug(
+                    f"could_scroll={can_scroll}, seen={len(self.seen)}, tabs={len(self.driver.window_handles)}"
+                )
+                if not can_scroll:
                     break
 
                 time.sleep(LOAD_SLEEP_SECS)

--- a/src/yt_community_post_archiver/arguments.py
+++ b/src/yt_community_post_archiver/arguments.py
@@ -73,6 +73,7 @@ class ArchiverSettings:
     take_screenshots: bool
     skip_existing: bool
     remote_debugging_port: int | None
+    debug: bool
 
 
 def _create_parser() -> argparse.ArgumentParser:
@@ -184,6 +185,11 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Connect to an running Chrome/Chromium instance launched with --remote-debugging-port=PORT.",
     )
     parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging for troubleshooting.",
+    )
+    parser.add_argument(
         "-v",
         "--version",
         action="version",
@@ -229,6 +235,7 @@ def get_settings() -> tuple[ArchiverSettings, int]:
             take_screenshots=args.take_screenshots,
             skip_existing=args.skip_existing,
             remote_debugging_port=args.remote_debugging_port,
+            debug=args.debug,
         ),
         rerun,
     )

--- a/src/yt_community_post_archiver/post_builder.py
+++ b/src/yt_community_post_archiver/post_builder.py
@@ -212,6 +212,11 @@ class PostBuilder:
     save_comments_types: set[CommentType]
     max_comments: int | None
     original_handle: str
+    debug: bool = False
+
+    def _debug(self, msg: str):
+        if self.debug:
+            print(f"[DEBUG] {msg}")
 
     def __open_post_in_tab(self, url: str) -> WebElement | None:
         self.driver.switch_to.new_window("tab")
@@ -275,8 +280,10 @@ class PostBuilder:
             return to_return
 
         comments = get_comment_elements()
+        self._debug(f"Initial comment elements found: {len(comments)}")
 
         if not comments:
+            self._debug("No comments found, returning early")
             return
 
         save_comments_types = self.save_comments_types
@@ -305,6 +312,9 @@ class PostBuilder:
         no_new_comments_counter = 0
 
         while True:
+            self._debug(
+                f"Comment loop iteration: {len(comments)} new comments, saved so far: {comments_saved}, no_new_counter: {no_new_comments_counter}"
+            )
             for comment_element, link in comments:
                 if not (
                     (CommentType.ALL in save_comments_types)
@@ -334,8 +344,14 @@ class PostBuilder:
             comments = get_comment_elements()
             if len(comments) == 0:
                 no_new_comments_counter += 1
+                self._debug(
+                    f"No new comments after scroll ({no_new_comments_counter}/5)"
+                )
 
                 if no_new_comments_counter >= 5:
+                    self._debug(
+                        f"Giving up on comments after 5 empty scrolls. Total saved: {comments_saved}"
+                    )
                     break
 
     def process_post(self) -> Post | None:
@@ -344,10 +360,14 @@ class PostBuilder:
 
         post_link = get_post_link(post)
         if post_link is None:
+            self._debug(f"No post link found for {url}")
             return
 
         relative_date = post_link.text
         is_members = _is_members_post(post)
+        self._debug(
+            f"Processing post: {url}, is_members={is_members}, members_filter={self.members}"
+        )
 
         if self.members is not None:
             if self.members == MembersPostType.MEMBERS_ONLY and (not is_members):
@@ -372,11 +392,18 @@ class PostBuilder:
         opened_post: None | WebElement = None
         opened_tab = False
 
+        self._debug(
+            f"Initial num_comments={num_comments}, will open tab: {num_comments is None}"
+        )
+
         # If there are no comments then we must not be in the post link itself.
         if num_comments is None:
             opened_post = self.__open_post_in_tab(url)
             num_comments = get_true_comment_count(self.driver)
             opened_tab = True
+            self._debug(
+                f"Opened tab: opened_post={'found' if opened_post else 'None'}, num_comments={num_comments}"
+            )
         else:
             opened_post = post
 
@@ -396,12 +423,23 @@ class PostBuilder:
         )
 
         post.save(self.output_dir)
+        self._debug(f"Post saved: {url}")
 
         if self.take_screenshots:
             self.__take_screenshots(opened_post)
 
         if self.save_comments_types:
+            self._debug(
+                f"Starting comment collection, types={self.save_comments_types}, max={self.max_comments}"
+            )
             self.__get_comments()
 
         if opened_tab and opened_post is not None:
+            self._debug(
+                f"Closing tab (opened_tab={opened_tab}, opened_post={'found' if opened_post else 'None'})"
+            )
             close_current_tab(self.driver, self.original_handle)
+        elif opened_tab:
+            self._debug(
+                "WARNING: Tab was opened but opened_post is None — tab NOT closed!"
+            )


### PR DESCRIPTION
When using --skip-existing, skipped post URLs were never added to self.seen, causing find_posts() to return the same URL repeatedly and the archiver to stall instead of advancing to new posts.

Also adds a --debug CLI flag that enables detailed logging for post processing, comment collection, tab management, and scroll detection to aid future troubleshooting.